### PR TITLE
Fix import, compose services and tests

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 
- livekit:
+services:
+  livekit:
     image: livekit/livekit-server:latest
     command: ["/livekit-server", "--config", "/etc/livekit.yaml"]
     ports:

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -23,7 +23,7 @@ from livekit.agents.vad import VAD
 
 from ..ai.model_manager import ModelManager
 from ..vision.screenshot_analyzer import ScreenshotAnalyzer
-from ..remote.control_handler import ControlHandler
+from ..remote.control_handler import RemoteControlHandler
 from ..utils.config import Config
 from ..utils.logging_setup import setup_logging
 
@@ -63,7 +63,7 @@ class BaseAgent:
         self.model_manager = ModelManager(config)
         # Passa l'istanza di ModelManager allo ScreenshotAnalyzer
         self.screenshot_analyzer = ScreenshotAnalyzer(self.model_manager)
-        self.control_handler = ControlHandler(config)
+        self.control_handler = RemoteControlHandler(config)
 
         # Stato sessioni
         self.sessions: Dict[str, SessionState] = {}

--- a/src/vision/screenshot_analyzer.py
+++ b/src/vision/screenshot_analyzer.py
@@ -135,7 +135,11 @@ class ScreenshotAnalyzer:
             return self._fallback_analysis(image)
 
     def _fallback_analysis(self, image: Image.Image) -> str:
-        """Analisi di base senza modelli AI."""
+        """Analisi di base senza modelli AI.
+
+        Ritorna:
+            str: stringa JSON con i dati sull'analisi dello screenshot.
+        """
         width, height = image.size
 
         # Converti in OpenCV per analisi base

--- a/tests/test_screenshot_analyzer.py
+++ b/tests/test_screenshot_analyzer.py
@@ -41,3 +41,20 @@ def test_fallback_analysis_with_red():
     assert result["severity"] == "medium"
     assert len(result["issues"]) == 1
     assert result["issues"][0]["type"] == "possible_error"
+
+
+def test_parse_analysis_result_json():
+    analyzer = _new_analyzer()
+    json_text = '{"issues": [{"description": "ok", "type": "info"}]}'
+    parsed = analyzer._parse_analysis_result(json_text)
+
+    assert parsed["issues"][0]["description"] == "ok"
+
+
+def test_parse_analysis_result_text():
+    analyzer = _new_analyzer()
+    text = "Generic failure"
+    parsed = analyzer._parse_analysis_result(text)
+
+    assert parsed["issues"][0]["description"] == text
+    assert parsed["system_info"].get("raw_analysis")


### PR DESCRIPTION
## Summary
- fix import name for RemoteControlHandler
- define `services:` in Docker compose
- clarify `_fallback_analysis` docstring
- add unit tests for `_parse_analysis_result`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461e6d988c8328b2d09722cee006ca